### PR TITLE
Align .env.example and deployment docs with current env var usage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,25 +1,20 @@
-AWS_ACCOUNT_ID=
-AWS_REGION=eu-west-2
-APP_VERSION=local
+# App runtime config
 PORT=3000
 LOG_LEVEL=info
-
-# Terraform / deploy script inputs
-TF_VAR_container_image=
-TF_VAR_github_app_id=
-
-# Optional override for Lambda image source (ECR URI).
-# If omitted, the deploy script defaults this to TF_VAR_container_image.
-LAMBDA_IMAGE_URI=
+APP_VERSION=local
 
 GITHUB_APP_ID=
 GITHUB_WEBHOOK_SECRET=
 GITHUB_WEBHOOK_SECRET_ARN=
 GITHUB_APP_PRIVATE_KEY=
 GITHUB_APP_PRIVATE_KEY_ARN=
+
 DISPATCH_REQUESTS_QUEUE_URL=
 DISPATCH_TARGETS_QUEUE_URL=
 DISPATCH_FACTS_EVENT_BUS_NAME=default
+DISPATCH_EVENTS_TABLE_NAME=
+DISPATCH_PROJECTIONS_TABLE_NAME=
+
 DEFAULT_DISPATCH_REF=main
 CREATE_ISSUES=true
 DISPATCH_MAX_RETRIES=2
@@ -30,3 +25,17 @@ SOURCE_REPO_ALLOWLIST=
 TARGET_REPO_ALLOWLIST=
 SOURCE_WORKFLOW_ALLOWLIST=
 ADMIN_IP_ALLOWLIST=
+
+# Local deploy script and Terraform helper inputs
+AWS_PROFILE=
+AWS_REGION=eu-west-2
+AWS_ACCOUNT_ID=
+TF_STATE_BUCKET=
+TF_STATE_REGION=
+TF_VAR_github_app_id=
+TF_VAR_container_image=
+TF_VAR_lambda_image_uri=
+
+# Optional Lambda image override for scripts/apply-dev-infra.sh.
+# If omitted, the script defaults TF_VAR_lambda_image_uri to TF_VAR_container_image.
+LAMBDA_IMAGE_URI=

--- a/README.md
+++ b/README.md
@@ -308,6 +308,8 @@ The GitHub Actions workflow at [.github/workflows/ci-cd.yml](.github/workflows/c
 | `AWS_REGION` | Variable | e.g. `eu-west-2` |
 | `ECR_REPOSITORY_DEV` | Variable | ECR repo name for dev, e.g. `dispatcher-v2-dev-dispatcher` |
 | `ECR_REPOSITORY_PROD` | Variable | ECR repo name for prod |
+| `TF_STATE_BUCKET` | Variable | Terraform remote state S3 bucket name |
+| `TF_STATE_REGION` | Variable | Region of the Terraform state bucket |
 
 Set secrets and variables with the GitHub CLI:
 
@@ -316,6 +318,8 @@ gh secret set AWS_ROLE_TO_ASSUME --body "arn:aws:iam::<account>:role/<role>"
 gh variable set AWS_REGION --body "eu-west-2"
 gh variable set ECR_REPOSITORY_DEV --body "dispatcher-v2-dev-dispatcher"
 gh variable set ECR_REPOSITORY_PROD --body "dispatcher-v2-prod-dispatcher"
+gh variable set TF_STATE_BUCKET --body "<your-tf-state-bucket>"
+gh variable set TF_STATE_REGION --body "eu-west-2"
 ```
 
 Create the `dev` and `prod` environments (add manual review protection to `prod`):
@@ -343,7 +347,7 @@ The deploy script at `scripts/apply-dev-infra.sh` wraps the full build-push-appl
 ./scripts/apply-dev-infra.sh --skip-image-build --auto-approve
 ```
 
-The script reads `AWS_PROFILE`, `AWS_REGION`, `AWS_ACCOUNT_ID`, `TF_VAR_container_image`, `TF_VAR_github_app_id`, and `LAMBDA_IMAGE_URI` from the environment or `.env`. Set `AWS_PROFILE` in `.env` to avoid passing it manually.
+The script reads `AWS_PROFILE`, `AWS_REGION`, `AWS_ACCOUNT_ID`, `GITHUB_APP_ID`, `TF_STATE_BUCKET`, `TF_STATE_REGION`, `TF_VAR_github_app_id`, `TF_VAR_container_image`, `TF_VAR_lambda_image_uri`, and `LAMBDA_IMAGE_URI` from the environment or `.env`. If `TF_VAR_github_app_id` is not set, it falls back to `GITHUB_APP_ID`. If `TF_VAR_lambda_image_uri` is not set, it falls back to `LAMBDA_IMAGE_URI` (and then `TF_VAR_container_image`).
 
 ---
 

--- a/docs/deployment-secrets.md
+++ b/docs/deployment-secrets.md
@@ -27,6 +27,8 @@ Set these in repository or environment variables:
 - AWS_REGION
 - ECR_REPOSITORY_DEV
 - ECR_REPOSITORY_PROD
+- TF_STATE_BUCKET
+- TF_STATE_REGION
 
 Set with gh CLI:
 
@@ -34,6 +36,8 @@ Set with gh CLI:
 gh variable set AWS_REGION --body "eu-west-2"
 gh variable set ECR_REPOSITORY_DEV --body "dispatcher-v2-dev-dispatcher"
 gh variable set ECR_REPOSITORY_PROD --body "dispatcher-v2-prod-dispatcher"
+gh variable set TF_STATE_BUCKET --body "<your-tf-state-bucket>"
+gh variable set TF_STATE_REGION --body "eu-west-2"
 ```
 
 Create environments with gh CLI:

--- a/infrastructure/terraform/README.md
+++ b/infrastructure/terraform/README.md
@@ -64,8 +64,9 @@ Optional runtime identity pattern (local shell):
 
 Optional helper script pattern (`scripts/apply-dev-infra.sh`):
 
-- The script reads `.env` values for `TF_VAR_github_app_id` and `TF_VAR_container_image`.
-- It also accepts `LAMBDA_IMAGE_URI=...` as an optional override; otherwise Lambdas use `TF_VAR_container_image`.
+- The script reads `.env` values for `AWS_PROFILE`, `AWS_REGION`, `AWS_ACCOUNT_ID`, `GITHUB_APP_ID`, `TF_STATE_BUCKET`, `TF_STATE_REGION`, `TF_VAR_github_app_id`, `TF_VAR_container_image`, `TF_VAR_lambda_image_uri`, and `LAMBDA_IMAGE_URI`.
+- `TF_VAR_github_app_id` falls back to `GITHUB_APP_ID` when omitted.
+- `TF_VAR_lambda_image_uri` falls back to `LAMBDA_IMAGE_URI`, then `TF_VAR_container_image`.
 
 4. Get webhook URL from output webhook_url and configure GitHub App webhook URL for:
 


### PR DESCRIPTION
## Summary
- update `.env.example` to reflect current runtime config variables from `src/config/env.ts`
- add missing Lambda runtime table env vars to `.env.example`
- align deploy helper env var documentation with `scripts/apply-dev-infra.sh`
- document required Terraform backend GitHub variables used by CI (`TF_STATE_BUCKET`, `TF_STATE_REGION`)

## Files changed
- `.env.example`
- `README.md`
- `docs/deployment-secrets.md`
- `infrastructure/terraform/README.md`

## Why
`.env.example` and deployment docs had drifted from current code/script behavior, which could cause setup confusion and missing CI variable configuration.

## Notes
- no runtime code changes
- documentation/template-only update